### PR TITLE
Support for the 'nodeify' method.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const Promise = require('bluebird');
 
 // then methods accept fulfilled and rejected handlers: they're expected to lazy
 // resolve the promise
-const THEN_METHODS = [ 'call', 'catch', 'done', 'error', 'finally', 'get', 'reflect', 'return', 'tap', 'then', 'throw' ];
+const THEN_METHODS = [ 'call', 'catch', 'done', 'error', 'finally', 'get', 'nodeify', 'reflect', 'return', 'tap', 'then', 'throw' ];
 // inspection methods just look at the current state of the promsie, but do not
 // trigger resolving
 const INSPECTION_METHODS = [ 'isFulfilled', 'isPending', 'isRejected', 'reason', 'value' ];

--- a/test.js
+++ b/test.js
@@ -20,7 +20,7 @@ describe('resolving promise', function() {
           .then(function() {
             resolved = true;
           })
-          .return([]);
+          .return([]);  // `.call()` and `.get()` need a value to operate on.
         resolve(outcome);
       });
 
@@ -59,6 +59,10 @@ describe('resolving promise', function() {
 
   describeMethod('get', function(promise) {
     return promise.get(0);
+  });
+
+  describeMethod('nodeify', function(promise) {
+    return promise.nodeify(noop, noop);
   });
 
   describeMethod('return', function(promise) {


### PR DESCRIPTION
When `zombie` adopted `lazybird`, flows like the following were broken:

```
describe('after pressing a button', function() {
  before(function(done) {
    browser.pressButton('button').nodeify(done);
  });

  it('does something', function() {
    . . .
  });
});
```

This change adds the `.nodeify()` method to `lazybird` in order to restore the previous functionality.
